### PR TITLE
Propagate enabled state on services regardless of core enabled state.

### DIFF
--- a/MobileCenter/MobileCenter/MSMobileCenter.m
+++ b/MobileCenter/MobileCenter/MSMobileCenter.m
@@ -212,22 +212,22 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
 }
 
 - (void)setEnabled:(BOOL)isEnabled {
+  self.enabledStateUpdating = YES;
   if ([self isEnabled] != isEnabled) {
-    self.enabledStateUpdating = YES;
 
     // Enable/disable pipeline.
     [self applyPipelineEnabledState:isEnabled];
 
-    // Propagate enable/disable on all services.
-    for (id<MSServiceInternal> service in self.services) {
-      [[service class] setEnabled:isEnabled];
-    }
-
     // Persist the enabled status.
     [kMSUserDefaults setObject:[NSNumber numberWithBool:isEnabled] forKey:kMSMobileCenterIsEnabledKey];
-    self.enabledStateUpdating = NO;
   }
-  MSLogInfo([MSMobileCenter getLoggerTag], @"Mobile Center SDK has been %@.", isEnabled ? @"enabled" : @"disabled");
+
+  // Propagate enable/disable on all services.
+  for (id<MSServiceInternal> service in self.services) {
+    [[service class] setEnabled:isEnabled];
+  }
+  self.enabledStateUpdating = NO;
+  MSLogInfo([MSMobileCenter getLoggerTag], @"Mobile Center SDK %@.", isEnabled ? @"enabled" : @"disabled");
 }
 
 - (BOOL)isEnabled {

--- a/MobileCenter/MobileCenterTests/MSServiceAbstractTest.m
+++ b/MobileCenter/MobileCenterTests/MSServiceAbstractTest.m
@@ -90,30 +90,52 @@
   assertThatBool(isEnabled, isTrue());
 }
 
-- (void)testSetEnabledToFalse {
+- (void)testDisableService {
 
   // If
   [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:self.abstractService.isEnabledKey];
-  [self.abstractService setEnabled:NO];
 
   // When
-  bool isEnabled = [self.abstractService isEnabled];
+  [self.abstractService setEnabled:NO];
 
   // Then
-  assertThatBool(isEnabled, isFalse());
+  assertThatBool([self.abstractService isEnabled], isFalse());
 }
 
-- (void)testSetEnabledToTrue {
+- (void)testEnableService {
 
   // If
   [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:self.abstractService.isEnabledKey];
-  [self.abstractService setEnabled:YES];
 
   // When
-  bool isEnabled = [self.abstractService isEnabled];
+  [self.abstractService setEnabled:YES];
 
   // Then
-  assertThatBool(isEnabled, isTrue());
+  assertThatBool([self.abstractService isEnabled], isTrue());
+}
+
+- (void)testDisableServiceOnServiceDisabled {
+
+  // If
+  [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:self.abstractService.isEnabledKey];
+
+  // When
+  [self.abstractService setEnabled:NO];
+
+  // Then
+  assertThatBool([self.abstractService isEnabled], isFalse());
+}
+
+- (void)testEnableServiceOnServiceEnabled {
+
+  // If
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:self.abstractService.isEnabledKey];
+
+  // When
+  [self.abstractService setEnabled:YES];
+
+  // Then
+  assertThatBool([self.abstractService isEnabled], isTrue());
 }
 
 - (void)testIsEnabledToPersistence {
@@ -176,47 +198,77 @@
   assertThatBool([[MSServiceAbstractImplementation sharedInstance] canBeUsed], isTrue());
 }
 
-- (void)testFeatureDisabledOnCoreDisabled {
-
-  // If
-  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
-  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
-
-  // When
-  [MSMobileCenter setEnabled:NO];
-
-  // Then
-  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isFalse());
-}
-
-- (void)testEnableFeatureOnCoreDisabled {
-
-  // If
-  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
-  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
-  [MSMobileCenter setEnabled:NO];
-
-  // When
-  [[MSServiceAbstractImplementation class] setEnabled:YES];
-
-  // Then
-  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isFalse());
-}
-
 - (void)testEnableServiceOnCoreDisabled {
 
   // If
   [MSMobileCenter resetSharedInstance];
-
-  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:self.abstractService.isEnabledKey];
   [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
-  [MSMobileCenter setEnabled:NO];
 
   // When
   [[MSServiceAbstractImplementation class] setEnabled:YES];
 
   // Then
   assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isFalse());
+}
+
+- (void)testDisableServiceOnCoreEnabled {
+
+  // If
+  [MSMobileCenter resetSharedInstance];
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:self.abstractService.isEnabledKey];
+  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
+
+  // When
+  [[MSServiceAbstractImplementation class] setEnabled:NO];
+
+  // Then
+  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isFalse());
+}
+
+- (void)testEnableServiceOnCoreEnabled {
+
+  // If
+  [MSMobileCenter resetSharedInstance];
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:self.abstractService.isEnabledKey];
+  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
+
+  // When
+  [[MSServiceAbstractImplementation class] setEnabled:YES];
+
+  // Then
+  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isTrue());
+}
+
+- (void)testReenableCoreOnServiceDisabled {
+
+  // If
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:NO] forKey:self.abstractService.isEnabledKey];
+  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
+
+  // When
+  [MSMobileCenter setEnabled:YES];
+
+  // Then
+  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isTrue());
+}
+
+- (void)testReenableCoreOnServiceEnabled {
+
+  // If
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:kMSMobileCenterIsEnabledKey];
+  [self.settingsMock setObject:[NSNumber numberWithBool:YES] forKey:self.abstractService.isEnabledKey];
+  [MSMobileCenter start:[[NSUUID UUID] UUIDString] withServices:@[ [MSServiceAbstractImplementation class] ]];
+
+  // When
+  [MSMobileCenter setEnabled:YES];
+
+  // Then
+  assertThatBool([[MSServiceAbstractImplementation class] isEnabled], isTrue());
 }
 
 - (void)testLogDeletedOnDisabled {


### PR DESCRIPTION
This fixes the following use case for instance: MobileCenter is enabled, MobileCenterAnalytics is disabled, re-enable MobileCenter, this automatically enables MobileCenterAnalytics.